### PR TITLE
Add a GitHub action for Whitehole

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -3,6 +3,8 @@ name: Build Whitehole
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:
@@ -30,6 +32,7 @@ jobs:
         name: Build
         path: "Build.zip"
     - name: Make a release
+      if: github.ref == 'refs/heads/master'
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -19,10 +19,25 @@ jobs:
       with:
         java-version: '15'
         distribution: 'adopt'
+    - name: Ant Cache
+      id: ant
+      uses: actions/cache@v2.1.6
+      with:
+        path: C:\ProgramData\chocolatey\bin\ant.exe
+        key: ${{ runner.os }}-ant
     - name: Install Apache Ant
-      run : choco install ant --acceptlicense --confirm
-    - name: Insatll cURL
-      run: choco install curl --acceptlicense --confirm
+      run: choco install ant --acceptlicense --confirm --verbose
+      shell: cmd
+    - name: Curl Cache
+      id: curl
+      uses: actions/cache@v2.1.6
+      with:
+        path: C:\ProgramData\chocolatey\bin\curl.exe
+        key: ${{ runner.os }}-curl
+    - name: Install cURL
+      if: steps.curl.outputs.cache-hit != 'true'
+      run: choco install curl --acceptlicense --confirm --verbose
+      shell: cmd
     - name: Build Whitehole
       run: Build.cmd
       shell: cmd

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,0 +1,40 @@
+name: Build Whitehole
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name : Checkout Repo
+      uses: actions/checkout@v2
+    - name: Set up JDK 15
+      uses: actions/setup-java@v2
+      with:
+        java-version: '15'
+        distribution: 'adopt'
+    - name: Install Apache Ant
+      run : choco install ant --acceptlicense --confirm
+    - name: Insatll cURL
+      run: choco install curl --acceptlicense --confirm
+    - name: Build Whitehole
+      run: Build.cmd
+      shell: cmd
+    - name: Upload Files
+      uses: actions/upload-artifact@v2
+      with:
+        name: Build
+        path: "Build.zip"
+    - name: Make a release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "auto"
+        prerelease: true
+        title: "Auto Build"
+        files: |
+          Build.zip

--- a/Build.cmd
+++ b/Build.cmd
@@ -1,0 +1,8 @@
+pushd %CD%
+ant -Dnb.internal.action.name=build jar
+cd dist
+rm -f README.TXT
+curl -k -L https://github.com/IonicPixels/Whitehole-Objectdb/raw/main/objectdb.xml -o objectdb.xml
+7z a ../Build.zip *.* -r
+popd
+echo Complete.


### PR DESCRIPTION
This PR adds a Github action and a build script in order to keep a nice and constant CI/CD for the project.
When a PUSH to master occurs, the action will make a Prerelease under the auto tag. This won't happen if it's a PR.